### PR TITLE
 added benchmark for event_db

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -37,10 +37,11 @@ add_dependencies(${BENCHMARK_LIBRARY} googlebenchmark)
 
 add_executable(hawktracer_benchmarks
     benchmark_main.cpp
-    benchmark_timeline.cpp)
+    benchmark_timeline.cpp
+    benchmark_event_db.cpp)
 
 target_include_directories(hawktracer_benchmarks PRIVATE ${BENCHMARK_INCLUDE_DIRS})
-target_link_libraries(hawktracer_benchmarks ${BENCHMARK_LIBRARY} hawktracer ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(hawktracer_benchmarks ${BENCHMARK_LIBRARY} hawktracer ${CMAKE_THREAD_LIBS_INIT} hawktracer_viewer)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   target_link_libraries(hawktracer_benchmarks Shlwapi)

--- a/benchmarks/benchmark_event_db.cpp
+++ b/benchmarks/benchmark_event_db.cpp
@@ -21,7 +21,7 @@ static void handle_event(const HawkTracer::parser::Event& event, HawkTracer::vie
 {
     const auto& klass = event.get_klass();
 
-    switch(static_cast<WellKnownKlasses>(klass->get_id()))
+    switch (static_cast<WellKnownKlasses>(klass->get_id()))
     {
         case WellKnownKlasses::EventKlassInfoEventKlass:
         case WellKnownKlasses::EventKlassFieldInfoEventKlass:
@@ -47,11 +47,12 @@ static void BenchmarkEventDbGetData(benchmark::State& state)
     ht_timeline_init(&timeline, 1024, HT_FALSE, HT_FALSE, nullptr);
 
     HT_FileDumpListener file_dump_listener;
-    HT_ErrorCode error_code = ht_file_dump_listener_init(&file_dump_listener, "test_output.htdump", 4096u);
+    const char* filename = "test_output.htdump";
+    HT_ErrorCode error_code = ht_file_dump_listener_init(&file_dump_listener, filename, 4096u);
     if (error_code != HT_ERR_OK)
     {
         char buffer[100];
-        sprintf(buffer, "Failed to initialize file dump listener! Error code: %d", error_code);
+        snprintf(buffer, 100, "Failed to initialize file dump listener! Error code: %d", error_code);
         state.SkipWithError(buffer);
         return;
     }
@@ -65,7 +66,7 @@ static void BenchmarkEventDbGetData(benchmark::State& state)
     ht_file_dump_listener_deinit(&file_dump_listener);
 
     // Arrange
-    auto stream = HawkTracer::parser::make_unique<HawkTracer::parser::FileStream>("test_output.htdump");
+    auto stream = HawkTracer::parser::make_unique<HawkTracer::parser::FileStream>(filename);
     HawkTracer::parser::KlassRegister klass_register;
     auto reader = HawkTracer::parser::make_unique<HawkTracer::parser::ProtocolReader>(&klass_register, std::move(stream), true);
     HawkTracer::viewer::EventDB event_db;
@@ -87,7 +88,7 @@ static void BenchmarkEventDbGetData(benchmark::State& state)
         auto result = event_db.get_data(start_ts, stop_ts, query);
     }
 
-    remove("test_output.htdump");
+    remove(filename);
 }
 // Passing the number of tracepoints to generate as the first argument
 BENCHMARK(BenchmarkEventDbGetData)->Arg(100);

--- a/benchmarks/benchmark_event_db.cpp
+++ b/benchmarks/benchmark_event_db.cpp
@@ -1,0 +1,103 @@
+#include <viewer/event_db.hpp>
+#include <viewer/base_ui.hpp>
+#include <hawktracer.h>
+#include <benchmark/benchmark.h>
+#include <hawktracer/parser/file_stream.hpp>
+#include <hawktracer/parser/protocol_reader.hpp>
+#include <hawktracer/parser/make_unique.hpp>
+
+using WellKnownKlasses = HawkTracer::parser::WellKnownKlasses;
+
+static void fnc_bar(HT_Timeline* timeline)
+{
+    HT_TP_SCOPED_STRING(timeline, "bar");
+}
+
+static void fnc_foo(HT_Timeline* timeline)
+{
+    HT_TP_SCOPED_STRING(timeline, "foo");
+    for (int i = 0; i < 10; i++)
+    {
+        fnc_bar(timeline);
+    }
+}
+
+static void fnc_start(HT_Timeline* timeline)
+{
+    HT_TP_SCOPED_STRING(timeline, "start");
+   for (int i = 0; i < 100; i++)
+    {
+        fnc_foo(timeline);
+    }
+}
+
+static void handle_event(const HawkTracer::parser::Event& event, HawkTracer::viewer::EventDB& event_db, HawkTracer::viewer::TimeRange& total_ts_range)
+{
+    const auto& klass = event.get_klass();
+
+    switch(static_cast<WellKnownKlasses>(klass->get_id()))
+    {
+        case WellKnownKlasses::EventKlassInfoEventKlass:
+        case WellKnownKlasses::EventKlassFieldInfoEventKlass:
+            break;
+        default:
+            event_db.insert(event);
+            auto ts = event.get_timestamp();
+            if (ts < total_ts_range.start)
+            {
+                total_ts_range.start = ts;
+            }
+            if (ts > total_ts_range.stop) 
+            {
+                total_ts_range.stop = ts;
+            }
+    }
+}
+
+static void BenchmarkEventDbGetData(benchmark::State& state)
+{
+    HawkTracer::viewer::TimeRange total_ts_range(0, 0);
+
+    //Insert events
+    HT_Timeline timeline;
+    ht_timeline_init(&timeline, 1024, HT_FALSE, HT_FALSE, nullptr);
+    ht_feature_callstack_enable(&timeline);
+
+    HT_FileDumpListener file_dump_listener;
+    if (ht_file_dump_listener_init(&file_dump_listener, "test_output.htdump", 4096u) != HT_FALSE)
+    {
+        ht_timeline_register_listener(&timeline, ht_file_dump_listener_callback, &file_dump_listener);
+    }
+    ht_registry_push_all_klass_info_events(&timeline);
+
+    fnc_start(&timeline);
+
+    ht_timeline_flush(&timeline);
+    ht_timeline_unregister_all_listeners(&timeline);
+    ht_file_dump_listener_deinit(&file_dump_listener);
+    
+    // Arrange
+    auto stream = HawkTracer::parser::make_unique<HawkTracer::parser::FileStream>("test_output.htdump");
+    HawkTracer::parser::KlassRegister klass_register;
+    auto reader = HawkTracer::parser::make_unique<HawkTracer::parser::ProtocolReader>(&klass_register, std::move(stream), true);
+    HawkTracer::viewer::EventDB event_db;
+    reader->register_events_listener([&event_db, &total_ts_range](const HawkTracer::parser::Event& event) {
+            handle_event(event, event_db, total_ts_range);
+            });
+
+    // Run viewer
+    reader->start();
+    reader->wait_for_complete();
+
+    // Query events
+    for (auto _ : state)
+    {
+        HT_TimestampNs start_ts = (HT_TimestampNs)total_ts_range.start;
+        HT_TimestampNs stop_ts = (HT_TimestampNs)total_ts_range.stop;
+        Query query;
+        auto result = event_db.get_data(start_ts, stop_ts, query);
+    }
+    ht_timeline_deinit(&timeline);
+}
+BENCHMARK(BenchmarkEventDbGetData);
+

--- a/benchmarks/benchmark_event_db.cpp
+++ b/benchmarks/benchmark_event_db.cpp
@@ -25,7 +25,7 @@ static void fnc_foo(HT_Timeline* timeline)
 static void fnc_start(HT_Timeline* timeline)
 {
     HT_TP_SCOPED_STRING(timeline, "start");
-   for (int i = 0; i < 100; i++)
+    for (int i = 0; i < 100; i++)
     {
         fnc_foo(timeline);
     }
@@ -58,7 +58,7 @@ static void BenchmarkEventDbGetData(benchmark::State& state)
 {
     HawkTracer::viewer::TimeRange total_ts_range(0, 0);
 
-    //Insert events
+    // Create timeline
     HT_Timeline timeline;
     ht_timeline_init(&timeline, 1024, HT_FALSE, HT_FALSE, nullptr);
     ht_feature_callstack_enable(&timeline);
@@ -68,14 +68,15 @@ static void BenchmarkEventDbGetData(benchmark::State& state)
     {
         ht_timeline_register_listener(&timeline, ht_file_dump_listener_callback, &file_dump_listener);
     }
-    ht_registry_push_all_klass_info_events(&timeline);
 
+    // Add events
+    ht_registry_push_all_klass_info_events(&timeline);
     fnc_start(&timeline);
 
     ht_timeline_flush(&timeline);
     ht_timeline_unregister_all_listeners(&timeline);
     ht_file_dump_listener_deinit(&file_dump_listener);
-    
+
     // Arrange
     auto stream = HawkTracer::parser::make_unique<HawkTracer::parser::FileStream>("test_output.htdump");
     HawkTracer::parser::KlassRegister klass_register;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added a benchmark for event_db.hpp which: 
- creates a timeline with some call stack events and writes them to "test_output.htdump" file
- runs the viewer's reader on the created file and benchmarks get_data() method from event_db.hpp

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
