### PR TITLE
Updating .gitignore, enabling compile_commands.json output from cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 .idea/
+build
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ option(ENABLE_RELEASE_MODE "Enables release mode. This flag should be used
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # PLATFORM FEATURES
 include(platform_features)
 define_platform_feature(CPU_USAGE "cpu_usage.c")


### PR DESCRIPTION
*Description of changes:*

This is a bit editor specific so not sure you'll want this here, but vscode generates a .vscode directory in the project root which I keep adding to git.

Also, enabled output of compile_commands.json from cmake.  This is useful for editors that can use it for include path resolution, but also static analysis and linting tools which need to be able to build.
