### PR TITLE
Implemented callgrind converter

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(hawktracer_client
     STATIC
+    call_graph.cpp
     callgrind_converter.cpp
     chrome_trace_converter.cpp
     converter.cpp

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -8,10 +8,10 @@ add_library(hawktracer_client
 
 target_include_directories(hawktracer_client PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
-add_executable(hawktracer-to-json main.cpp)
+add_executable(hawktracer-converter main.cpp)
 
 target_link_libraries(hawktracer_client hawktracer_parser)
-target_link_libraries(hawktracer-to-json hawktracer_client)
+target_link_libraries(hawktracer-converter hawktracer_client)
 
-install(TARGETS hawktracer-to-json
+install(TARGETS hawktracer-converter
     RUNTIME DESTINATION bin)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,11 +1,17 @@
-add_executable(hawktracer-to-json
-    main.cpp
+add_library(hawktracer_client
+    STATIC
     callgrind_converter.cpp
     chrome_trace_converter.cpp
     converter.cpp
     tcp_client_stream.cpp
     tracepoint_map.cpp)
-target_link_libraries(hawktracer-to-json hawktracer_parser)
+
+target_include_directories(hawktracer_client PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+add_executable(hawktracer-to-json main.cpp)
+
+target_link_libraries(hawktracer_client hawktracer_parser)
+target_link_libraries(hawktracer-to-json hawktracer_client)
 
 install(TARGETS hawktracer-to-json
     RUNTIME DESTINATION bin)

--- a/client/call_graph.cpp
+++ b/client/call_graph.cpp
@@ -1,0 +1,104 @@
+#include "call_graph.hpp"
+
+#include <algorithm>
+
+namespace HawkTracer
+{
+namespace client
+{
+
+void CallGraph::make(std::vector<std::pair<HT_ThreadId, TreeNode>>& events)
+{
+    std::sort(events.begin(), events.end(), 
+            [](const std::pair<HT_ThreadId, TreeNode>& e1, const std::pair<HT_ThreadId, TreeNode>& e2){
+                return e1.second.start_ts < e2.second.start_ts;
+            });
+    for (const auto& event : events)
+    {
+        _add_event(event.first, event.second.label, event.second.start_ts, event.second.duration);
+    }
+}
+
+void CallGraph::_add_new_calltree(HT_ThreadId thread_id,
+                                  std::string label,
+                                  HT_TimestampNs start_ts,
+                                  HT_DurationNs duration)
+{
+    auto& root_calls_for_thread_id = root_calls[thread_id];
+    auto call = std::find_if(root_calls_for_thread_id.begin(), root_calls_for_thread_id.end(),
+            [&label](const std::pair<std::shared_ptr<TreeNode>, int>& call) {
+            return call.first.get()->label == label;
+            });
+    if (call != root_calls_for_thread_id.end())
+    {
+        call->first->duration += duration;
+        call->first->start_ts = start_ts;
+        ++call->second;
+    }
+    else
+    {
+        _calls[thread_id] = std::make_shared<TreeNode>(label, start_ts, duration);
+        root_calls_for_thread_id.emplace_back(_calls[thread_id], 1);
+    }
+
+}
+
+void CallGraph::_add_event(HT_ThreadId thread_id,
+                           std::string label,
+                           HT_TimestampNs start_ts,
+                           HT_DurationNs duration)
+{
+    auto thread_calls = _calls.find(thread_id);
+
+    if (thread_calls == _calls.end())
+    {
+        _add_new_calltree(thread_id, label, start_ts, duration);
+    }
+    else
+    {
+        std::shared_ptr<TreeNode> previous_event = _calls[thread_id];
+
+        while(previous_event.get())
+        {
+            bool previous_event_contains_current_event = 
+                previous_event->start_ts <= start_ts && start_ts + duration <= previous_event->get_stop_ts();
+
+            if (previous_event_contains_current_event)
+            {
+                previous_event->total_children_duration += duration;
+
+                auto call = std::find_if(previous_event->children.begin(), previous_event->children.end(),
+                        [&label](const std::pair<std::shared_ptr<TreeNode>, int>& child) {
+                            return child.first.get()->label == label;
+                        });
+                if (call != previous_event->children.end())
+                {
+                    call->first->duration += duration;
+                    call->first->start_ts = start_ts;
+                    ++call->second;
+                    _calls[thread_id] = call->first;
+                }
+                else
+                {
+                    auto eventNode = std::make_shared<TreeNode>(label, start_ts, duration);
+                    eventNode->parent = previous_event;
+                    previous_event->children.emplace_back(eventNode, 1);
+                    _calls[thread_id] = eventNode;
+                }
+
+                break;
+            }
+            else
+            {
+               previous_event = previous_event->parent;
+            }
+        }
+        if (previous_event.get() == nullptr)
+        {
+            _add_new_calltree(thread_id, label, start_ts, duration);
+        }
+    }
+}
+
+} // namespace client
+} // namespace HawkTracer

--- a/client/call_graph.cpp
+++ b/client/call_graph.cpp
@@ -7,97 +7,111 @@ namespace HawkTracer
 namespace client
 {
 
-void CallGraph::make(std::vector<std::pair<HT_ThreadId, TreeNode>>& events)
+std::unordered_map<HT_ThreadId, std::vector<std::pair<std::shared_ptr<CallGraph::TreeNode>, int>>> 
+    CallGraph::make(std::vector<std::pair<HT_ThreadId, NodeData>>& events)
 {
     std::sort(events.begin(), events.end(), 
-            [](const std::pair<HT_ThreadId, TreeNode>& e1, const std::pair<HT_ThreadId, TreeNode>& e2){
-                return e1.second.last_start_ts < e2.second.last_start_ts;
+            [](const std::pair<HT_ThreadId, NodeData>& e1, const std::pair<HT_ThreadId, NodeData>& e2){
+                return e1.second.start_ts < e2.second.start_ts;
             });
     for (const auto& event : events)
     {
-        _add_event(event.first, event.second.label, event.second.last_start_ts, event.second.total_duration);
+        _add_event(event.first, event.second);
     }
+
+    return _root_calls;
 }
 
 void CallGraph::_add_new_calltree(HT_ThreadId thread_id,
-                                  std::string label,
-                                  HT_TimestampNs start_ts,
-                                  HT_DurationNs duration)
+                                  NodeData& node_data)
 {
-    auto& root_calls_for_thread_id = root_calls[thread_id];
+    auto& root_calls_for_thread_id = _root_calls[thread_id];
+    std::string label = node_data.label;
     auto call = std::find_if(root_calls_for_thread_id.begin(), root_calls_for_thread_id.end(),
             [&label](const std::pair<std::shared_ptr<TreeNode>, int>& call) {
-            return call.first.get()->label == label;
+                return call.first.get()->data.label == label;
             });
     if (call != root_calls_for_thread_id.end())
     {
-        call->first->total_duration += duration;
-        call->first->last_start_ts = start_ts;
-        call->first->last_stop_ts = start_ts + duration;
+        call->first->total_duration += node_data.get_duration();
+        call->first->data = node_data;
         ++call->second;
     }
     else
     {
-        _calls[thread_id] = std::make_shared<TreeNode>(label, start_ts, duration);
+        _calls[thread_id] = std::make_shared<TreeNode>(node_data);
         root_calls_for_thread_id.emplace_back(_calls[thread_id], 1);
     }
 
 }
 
+std::shared_ptr<CallGraph::TreeNode> CallGraph::_add_new_event_call(std::shared_ptr<TreeNode>& caller,
+                                                                    NodeData& node_data)
+{
+    caller->total_children_duration += node_data.get_duration();
+
+    std::string label = node_data.label;
+    auto call = std::find_if(caller->children.begin(), caller->children.end(),
+            [&label](const std::pair<std::shared_ptr<TreeNode>, int>& child) {
+                return child.first.get()->data.label == label;
+            });
+    if (call != caller->children.end())
+    {
+        call->first->total_duration += node_data.get_duration();
+        call->first->data = node_data;
+        ++call->second;
+
+        return call->first;
+    }
+    else
+    {
+        auto eventNode = std::make_shared<TreeNode>(node_data);
+        eventNode->parent = caller;
+        caller->children.emplace_back(eventNode, 1);
+
+        return eventNode;
+    }
+}
+
+bool CallGraph::_try_add_event_to_existing_calltree(HT_ThreadId thread_id,
+                                                    NodeData& node_data)
+{
+    std::shared_ptr<TreeNode> previous_event = _calls[thread_id];
+    bool event_added;
+
+    while(previous_event.get() && !event_added)
+    {
+        bool previous_event_contains_current_event = 
+            previous_event->data.start_ts <= node_data.start_ts && node_data.stop_ts <= previous_event->data.stop_ts;
+
+        if (previous_event_contains_current_event)
+        {
+            _calls[thread_id] =  _add_new_event_call(previous_event, node_data);
+            event_added = true;
+        }
+        else 
+        {
+            previous_event = previous_event->parent;
+        }
+    }
+    return event_added;
+}
+
 void CallGraph::_add_event(HT_ThreadId thread_id,
-                           std::string label,
-                           HT_TimestampNs start_ts,
-                           HT_DurationNs duration)
+                           NodeData node_data)
 {
     auto thread_calls = _calls.find(thread_id);
 
     if (thread_calls == _calls.end())
     {
-        _add_new_calltree(thread_id, label, start_ts, duration);
+        _add_new_calltree(thread_id, node_data);
     }
     else
     {
-        std::shared_ptr<TreeNode> previous_event = _calls[thread_id];
-
-        while(previous_event.get())
+        bool added = _try_add_event_to_existing_calltree(thread_id, node_data);
+        if (!added) 
         {
-            bool previous_event_contains_current_event = 
-                previous_event->last_start_ts <= start_ts && start_ts + duration <= previous_event->last_stop_ts;
-
-            if (previous_event_contains_current_event)
-            {
-                previous_event->total_children_duration += duration;
-
-                auto call = std::find_if(previous_event->children.begin(), previous_event->children.end(),
-                        [&label](const std::pair<std::shared_ptr<TreeNode>, int>& child) {
-                            return child.first.get()->label == label;
-                        });
-                if (call != previous_event->children.end())
-                {
-                    call->first->total_duration += duration;
-                    call->first->last_start_ts = start_ts;
-                    call->first->last_stop_ts = start_ts + duration;
-                    ++call->second;
-                    _calls[thread_id] = call->first;
-                }
-                else
-                {
-                    auto eventNode = std::make_shared<TreeNode>(label, start_ts, duration);
-                    eventNode->parent = previous_event;
-                    previous_event->children.emplace_back(eventNode, 1);
-                    _calls[thread_id] = eventNode;
-                }
-
-                break;
-            }
-            else
-            {
-               previous_event = previous_event->parent;
-            }
-        }
-        if (previous_event.get() == nullptr)
-        {
-            _add_new_calltree(thread_id, label, start_ts, duration);
+            _add_new_calltree(thread_id, node_data);
         }
     }
 }

--- a/client/call_graph.hpp
+++ b/client/call_graph.hpp
@@ -52,21 +52,17 @@ public:
         }
     };
 
-    std::unordered_map<HT_ThreadId, std::vector<std::pair<std::shared_ptr<TreeNode>, int>>> make(
-            std::vector<std::pair<HT_ThreadId, NodeData>>& events);
+    std::vector<std::pair<std::shared_ptr<TreeNode>, int>> make(std::vector<NodeData>& events);
 
 private:
-    // stores for eached thread a vector with all the root_calls and how many times they are called
-    std::unordered_map<HT_ThreadId, std::vector<std::pair<std::shared_ptr<TreeNode>, int>>> _root_calls;
+    //  vector with all the root calls and how many times they are called
+    std::vector<std::pair<std::shared_ptr<TreeNode>, int>> _root_calls;
 
-    std::unordered_map<HT_ThreadId, std::shared_ptr<TreeNode>> _calls;
+    std::shared_ptr<TreeNode> _current_call;
 
-    void _add_event(HT_ThreadId thread_id,
-                    NodeData node_data);
-    void _add_new_calltree(HT_ThreadId thread_id, 
-                           NodeData& node_data);
-    bool _try_add_event_to_existing_calltree(HT_ThreadId thread_id,
-                                             NodeData& node_data);
+    void _add_event(NodeData node_data);
+    void _add_new_calltree(NodeData& node_data);
+    bool _try_add_event_to_existing_calltree(NodeData& node_data);
     std::shared_ptr<TreeNode> _add_new_event_call(std::shared_ptr<TreeNode>& caller,
                                                   NodeData& node_data);
 

--- a/client/call_graph.hpp
+++ b/client/call_graph.hpp
@@ -15,8 +15,9 @@ public:
     struct TreeNode
     {
         std::string label;
-        HT_TimestampNs start_ts;
-        HT_DurationNs duration;
+        HT_TimestampNs last_start_ts;
+        HT_TimestampNs last_stop_ts;
+        HT_DurationNs total_duration;
         HT_DurationNs total_children_duration;
 
         std::vector<std::pair<std::shared_ptr<TreeNode>, int>> children;
@@ -25,14 +26,10 @@ public:
         TreeNode(std::string name, HT_TimestampNs start, HT_DurationNs dur)
         {
             label = name;
-            start_ts = start;
-            duration = dur;
+            last_start_ts = start;
+            last_stop_ts = start + dur;
+            total_duration = dur;
             total_children_duration = 0u;
-        }
-        
-        HT_TimestampNs get_stop_ts() const
-        {
-            return start_ts + duration;
         }
     };
 

--- a/client/call_graph.hpp
+++ b/client/call_graph.hpp
@@ -12,43 +12,64 @@ namespace client
 class CallGraph
 {
 public:
-    struct TreeNode
+    struct NodeData
     {
         std::string label;
-        HT_TimestampNs last_start_ts;
-        HT_TimestampNs last_stop_ts;
+        HT_TimestampNs start_ts;
+        HT_TimestampNs stop_ts;
+
+        NodeData()
+        {
+        }
+
+        NodeData(std::string name, HT_TimestampNs start, HT_DurationNs dur)
+        {
+            label = name;
+            start_ts = start;
+            stop_ts = start_ts + dur;
+        }
+
+        HT_DurationNs get_duration() const
+        {
+            return stop_ts - start_ts;
+        }
+    };
+
+    struct TreeNode
+    {
+        NodeData data;
         HT_DurationNs total_duration;
         HT_DurationNs total_children_duration;
 
         std::vector<std::pair<std::shared_ptr<TreeNode>, int>> children;
         std::shared_ptr<TreeNode> parent;
 
-        TreeNode(std::string name, HT_TimestampNs start, HT_DurationNs dur)
+        TreeNode(NodeData node_data)
         {
-            label = name;
-            last_start_ts = start;
-            last_stop_ts = start + dur;
-            total_duration = dur;
+            data = node_data;
+            total_duration = node_data.get_duration();
             total_children_duration = 0u;
         }
     };
 
-
-    std::unordered_map<HT_ThreadId, std::vector<std::pair<std::shared_ptr<TreeNode>, int>>> root_calls;
-
-    void make(std::vector<std::pair<HT_ThreadId, TreeNode>>& events);
+    std::unordered_map<HT_ThreadId, std::vector<std::pair<std::shared_ptr<TreeNode>, int>>> make(
+            std::vector<std::pair<HT_ThreadId, NodeData>>& events);
 
 private:
+    // stores for eached thread a vector with all the root_calls and how many times they are called
+    std::unordered_map<HT_ThreadId, std::vector<std::pair<std::shared_ptr<TreeNode>, int>>> _root_calls;
+
     std::unordered_map<HT_ThreadId, std::shared_ptr<TreeNode>> _calls;
 
-    void _add_event(HT_ThreadId thread_id, 
-                    std::string label,
-                    HT_TimestampNs start_ts,
-                    HT_DurationNs duration);
+    void _add_event(HT_ThreadId thread_id,
+                    NodeData node_data);
     void _add_new_calltree(HT_ThreadId thread_id, 
-                           std::string label,
-                           HT_TimestampNs start_ts,
-                           HT_DurationNs duration);
+                           NodeData& node_data);
+    bool _try_add_event_to_existing_calltree(HT_ThreadId thread_id,
+                                             NodeData& node_data);
+    std::shared_ptr<TreeNode> _add_new_event_call(std::shared_ptr<TreeNode>& caller,
+                                                  NodeData& node_data);
+
 };
 
 } // namespace client

--- a/client/call_graph.hpp
+++ b/client/call_graph.hpp
@@ -1,0 +1,60 @@
+#ifndef HAWKTRACER_CLIENT_CALL_GRAPH_HPP
+#define HAWKTRACER_CLIENT_CALL_GRAPH_HPP
+
+#include <hawktracer/parser/event.hpp>
+#include "tracepoint_map.hpp"
+
+namespace HawkTracer
+{
+namespace client
+{
+
+class CallGraph
+{
+public:
+    struct TreeNode
+    {
+        std::string label;
+        HT_TimestampNs start_ts;
+        HT_DurationNs duration;
+        HT_DurationNs total_children_duration;
+
+        std::vector<std::pair<std::shared_ptr<TreeNode>, int>> children;
+        std::shared_ptr<TreeNode> parent;
+
+        TreeNode(std::string name, HT_TimestampNs start, HT_DurationNs dur)
+        {
+            label = name;
+            start_ts = start;
+            duration = dur;
+            total_children_duration = 0u;
+        }
+        
+        HT_TimestampNs get_stop_ts() const
+        {
+            return start_ts + duration;
+        }
+    };
+
+
+    std::unordered_map<HT_ThreadId, std::vector<std::pair<std::shared_ptr<TreeNode>, int>>> root_calls;
+
+    void make(std::vector<std::pair<HT_ThreadId, TreeNode>>& events);
+
+private:
+    std::unordered_map<HT_ThreadId, std::shared_ptr<TreeNode>> _calls;
+
+    void _add_event(HT_ThreadId thread_id, 
+                    std::string label,
+                    HT_TimestampNs start_ts,
+                    HT_DurationNs duration);
+    void _add_new_calltree(HT_ThreadId thread_id, 
+                           std::string label,
+                           HT_TimestampNs start_ts,
+                           HT_DurationNs duration);
+};
+
+} // namespace client
+} // namespace HawkTracer
+
+#endif //HAWKTRACER_CLIENT_CALL_GRAPH_HPP

--- a/client/call_graph.hpp
+++ b/client/call_graph.hpp
@@ -60,11 +60,14 @@ private:
 
     std::shared_ptr<TreeNode> _current_call;
 
-    void _add_event(NodeData node_data);
-    void _add_new_calltree(NodeData& node_data);
-    bool _try_add_event_to_existing_calltree(NodeData& node_data);
-    std::shared_ptr<TreeNode> _add_new_event_call(std::shared_ptr<TreeNode>& caller,
-                                                  NodeData& node_data);
+    void _add_event(const NodeData& node_data);
+    void _add_new_calltree(const NodeData& node_data);
+    bool _try_add_event_to_existing_calltree(const NodeData& node_data);
+    void _add_new_event_call(const std::shared_ptr<TreeNode>& caller,
+                             const NodeData& node_data);
+    std::shared_ptr<TreeNode> _add_new_call(const NodeData& node_data,
+                                            const std::shared_ptr<TreeNode>& parent,
+                                            std::vector<std::pair<std::shared_ptr<TreeNode>, int>>& calls);
 
 };
 

--- a/client/callgrind_converter.cpp
+++ b/client/callgrind_converter.cpp
@@ -1,6 +1,7 @@
 #include "callgrind_converter.hpp"
 
 #include <algorithm>
+#include <iostream>
 
 namespace HawkTracer
 {
@@ -9,7 +10,6 @@ namespace client
 
 CallgrindConverter::~CallgrindConverter()
 {
-    uninit();
 }
 
 bool CallgrindConverter::init(const std::string& file_name)
@@ -17,13 +17,6 @@ bool CallgrindConverter::init(const std::string& file_name)
     _file_name = file_name;
     return true;
 }
-
-
-void CallgrindConverter::uninit()
-{
-}
-
-
 
 void CallgrindConverter::process_event(const parser::Event& event)
 {
@@ -64,7 +57,7 @@ void CallgrindConverter::_print_function(std::ofstream& file, std::shared_ptr<Ca
     }
 }
 
-bool CallgrindConverter::stop()
+void CallgrindConverter::stop()
 {
     _call_graph.make(_events);
     for (auto& calls : _call_graph.root_calls)
@@ -85,11 +78,9 @@ bool CallgrindConverter::stop()
         }
         else
         {
-            return false;
+            std::cerr << "Can't open file: " << _file_name + "." + std::to_string(calls.first);
         }
     }
-    uninit();
-    return true;
 }
 
 } // namespace client

--- a/client/callgrind_converter.cpp
+++ b/client/callgrind_converter.cpp
@@ -27,8 +27,8 @@ void CallgrindConverter::process_event(const parser::Event& event)
     {
         return;
     }
-    HT_ThreadId thread_id = event.get_value_or_default<HT_ThreadId>("thread_id", 0);
-    HT_TimestampNs start_ts = event.get_value<HT_TimestampNs>("timestamp");
+    HT_ThreadId thread_id = event.get_value_or_default<HT_ThreadId>("thread_id", 0u);
+    HT_TimestampNs start_ts = event.get_timestamp();
     HT_DurationNs duration = event.get_value_or_default<HT_DurationNs>("duration", 0u);
     _events[thread_id].emplace_back(label, start_ts, duration);
 }
@@ -62,10 +62,11 @@ void CallgrindConverter::stop()
         CallGraph _call_graph;
         auto root_calls = _call_graph.make(thread.second);
 
-        std::ofstream thread_output_file(_file_name + "." + std::to_string(thread.first));
+        std::string thread_file_name = _file_name + "." + std::to_string(thread.first);
+        std::ofstream thread_output_file(thread_file_name);
         if (thread_output_file.is_open())
         {
-            thread_output_file << callgrind_header << std::endl;
+            thread_output_file << _callgrind_header << std::endl;
             thread_output_file << "thread: " << thread.first << "\n\n";
             thread_output_file << "events: Duration" << "\n";
             for (auto& root : root_calls)
@@ -75,7 +76,7 @@ void CallgrindConverter::stop()
         }
         else
         {
-            std::cerr << "Can't open file: " << _file_name + "." + std::to_string(thread.first);
+            std::cerr << "Can't open file: " << thread_file_name << std::endl;
         }
         thread_output_file.close();
     }

--- a/client/callgrind_converter.cpp
+++ b/client/callgrind_converter.cpp
@@ -15,15 +15,7 @@ CallgrindConverter::~CallgrindConverter()
 bool CallgrindConverter::init(const std::string& file_name)
 {
     _file_name = file_name;
-    std::ofstream blank_file;
-    blank_file.open(file_name);
-    if (blank_file.is_open())
-    {
-        blank_file << callgrind_header << std::endl;
-        blank_file.close();
-        return true;
-    }
-    return false;
+    return true;
 }
 
 
@@ -80,7 +72,7 @@ bool CallgrindConverter::stop()
         std::ofstream thread_output_file(_file_name + "." + std::to_string(calls.first));
         if (thread_output_file.is_open())
         {
-            thread_output_file<< "# callgrind format\n";
+            thread_output_file << callgrind_header << std::endl;
             thread_output_file << "thread: " << calls.first << "\n\n";
             thread_output_file << "events: Duration" << "\n";
 

--- a/client/callgrind_converter.cpp
+++ b/client/callgrind_converter.cpp
@@ -42,13 +42,13 @@ void CallgrindConverter::_print_function(std::ofstream& file, std::shared_ptr<Ca
     {
         auto& fnc = fnc_queue.front();
         file << "fn=" << fnc.second << "\n";
-        file << "1 " << fnc.first->duration - fnc.first->total_children_duration << "\n";
+        file << "1 " << fnc.first->total_duration - fnc.first->total_children_duration << "\n";
         for (const auto& child : fnc.first->children)
         {
             std::string child_label = child.first->label + "()'" + fnc.second;
             file << "cfn=" << child_label << "\n";
             file << "calls=" << child.second << " 1\n";
-            file << "1 " << child.first->duration << "\n";
+            file << "1 " << child.first->total_duration << "\n";
             fnc_queue.emplace(child.first, child_label);
         }
         fnc_queue.pop();

--- a/client/callgrind_converter.cpp
+++ b/client/callgrind_converter.cpp
@@ -31,86 +31,7 @@ void CallgrindConverter::uninit()
 {
 }
 
-void CallgrindConverter::_add_new_calltree(HT_ThreadId thread_id,
-                                           std::string label,
-                                           HT_TimestampNs start_ts,
-                                           HT_DurationNs duration)
-{
-    auto& _root_calls_for_thread_id = _root_calls[thread_id];
-    auto call = std::find_if(_root_calls_for_thread_id.begin(), _root_calls_for_thread_id.end(),
-            [&label](const std::pair<TreeNode*, int>& call) {
-            return call.first->label == label;
-            });
-    if (call != _root_calls_for_thread_id.end())
-    {
-        call->first->duration += duration;
-        call->first->start_ts = start_ts;
-        ++call->second;
-    }
-    else
-    {
-        _calls[thread_id] = new TreeNode(label, start_ts, duration);
-        _root_calls_for_thread_id.emplace_back(_calls[thread_id], 1);
-    }
 
-}
-
-void CallgrindConverter::_add_event(HT_ThreadId thread_id,
-                                    std::string label,
-                                    HT_TimestampNs start_ts,
-                                    HT_DurationNs duration)
-{
-    auto thread_calls = _calls.find(thread_id);
-
-    if (thread_calls == _calls.end())
-    {
-        _add_new_calltree(thread_id, label, start_ts, duration);
-    }
-    else
-    {
-        auto& previous_event = _calls[thread_id];
-
-        while(previous_event != nullptr)
-        {
-            bool previous_event_contains_current_event = 
-                previous_event->start_ts <= start_ts && start_ts + duration <= previous_event->get_stop_ts();
-
-            if (previous_event_contains_current_event)
-            {
-                previous_event->total_children_duration += duration;
-
-                auto call = std::find_if(previous_event->children.begin(), previous_event->children.end(),
-                        [&label](const std::pair<TreeNode*, int>& child) {
-                            return child.first->label == label;
-                        });
-                if (call != previous_event->children.end())
-                {
-                    call->first->duration += duration;
-                    call->first->start_ts = start_ts;
-                    ++call->second;
-                    _calls[thread_id] = call->first;
-                }
-                else
-                {
-                    TreeNode* eventNode = new TreeNode(label, start_ts, duration);
-                    eventNode->parent = previous_event;
-                    previous_event->children.emplace_back(eventNode, 1);
-                    _calls[thread_id] = eventNode;
-                }
-
-                break;
-            }
-            else
-            {
-               previous_event = previous_event->parent;
-            }
-        }
-        if (previous_event == nullptr)
-        {
-            _add_new_calltree(thread_id, label, start_ts, duration);
-        }
-    }
-}
 
 void CallgrindConverter::process_event(const parser::Event& event)
 {
@@ -123,10 +44,10 @@ void CallgrindConverter::process_event(const parser::Event& event)
     HT_ThreadId thread_id = event.get_value_or_default<HT_ThreadId>("thread_id", 0);
     HT_TimestampNs start_ts = event.get_value<HT_TimestampNs>("timestamp");
     HT_DurationNs duration = event.get_value_or_default<HT_DurationNs>("duration", 0u);
-    _events.emplace_back(thread_id, TreeNode(label, start_ts, duration));
+    _events.emplace_back(thread_id, CallGraph::TreeNode(label, start_ts, duration));
 }
 
-void CallgrindConverter::_print_function(std::ofstream& file, TreeNode* node, std::string label)
+void CallgrindConverter::_print_function(std::ofstream& file, CallGraph::TreeNode* node, std::string label)
 {
     if (label != "")
     {
@@ -138,7 +59,7 @@ void CallgrindConverter::_print_function(std::ofstream& file, TreeNode* node, st
     }
     file << "fn=" << label << "\n";
     file << "1 " << node->duration - node->total_children_duration << "\n";
-    for (auto& child : node->children)
+    for (const auto& child : node->children)
     {
         std::string child_label = child.first->label + "()'" + label;
         file << "cfn=" << child_label << "\n";
@@ -153,12 +74,8 @@ void CallgrindConverter::_print_function(std::ofstream& file, TreeNode* node, st
 
 bool CallgrindConverter::stop()
 {
-    for (auto it = _events.rbegin(); it != _events.rend(); ++it)
-    {
-        _add_event(it->first, it->second.label, it->second.start_ts, it->second.duration);
-    }
-
-    for (auto& calls : _root_calls)
+    _call_graph.make(_events);
+    for (auto& calls : _call_graph.root_calls)
     {
         std::ofstream thread_output_file(_file_name + "." + std::to_string(calls.first));
         if (thread_output_file.is_open())

--- a/client/callgrind_converter.cpp
+++ b/client/callgrind_converter.cpp
@@ -116,6 +116,10 @@ void CallgrindConverter::process_event(const parser::Event& event)
 {
     std::string label = get_label(event);
 
+    if (label == "")
+    {
+        return;
+    }
     uint32_t thread_id = event.get_value_or_default<uint32_t>("thread_id", 0);
     HT_TimestampNs start_ts = event.get_value<uint64_t>("timestamp");
     HT_TimestampNs duration = event.get_value_or_default<uint64_t>("duration", 0u);

--- a/client/callgrind_converter.cpp
+++ b/client/callgrind_converter.cpp
@@ -47,7 +47,7 @@ void CallgrindConverter::process_event(const parser::Event& event)
     _events.emplace_back(thread_id, CallGraph::TreeNode(label, start_ts, duration));
 }
 
-void CallgrindConverter::_print_function(std::ofstream& file, CallGraph::TreeNode* node, std::string label)
+void CallgrindConverter::_print_function(std::ofstream& file, std::shared_ptr<CallGraph::TreeNode> node, std::string label)
 {
     if (label != "")
     {

--- a/client/callgrind_converter.hpp
+++ b/client/callgrind_converter.hpp
@@ -23,7 +23,7 @@ public:
     void stop() override;
 
 private:
-    const std::string callgrind_header = "# callgrind format";
+    const std::string _callgrind_header = "# callgrind format";
     std::string _file_name;
     std::unordered_map<HT_ThreadId, std::vector<CallGraph::NodeData>> _events;
 

--- a/client/callgrind_converter.hpp
+++ b/client/callgrind_converter.hpp
@@ -25,7 +25,7 @@ public:
 private:
     const std::string callgrind_header = "# callgrind format";
     std::string _file_name;
-    std::vector<std::pair<HT_ThreadId, CallGraph::TreeNode>> _events;
+    std::vector<std::pair<HT_ThreadId, CallGraph::NodeData>> _events;
     CallGraph _call_graph;
 
     void _print_function(std::ofstream& file, std::shared_ptr<CallGraph::TreeNode> node, std::string label);

--- a/client/callgrind_converter.hpp
+++ b/client/callgrind_converter.hpp
@@ -3,10 +3,10 @@
 
 #include <hawktracer/parser/event.hpp>
 #include "converter.hpp"
+#include "call_graph.hpp"
 #include "tracepoint_map.hpp"
 
 #include <fstream>
-#include <stack>
 
 namespace HawkTracer
 {
@@ -24,45 +24,12 @@ public:
     bool stop() override;
 
 private:
-    struct TreeNode
-    {
-        std::string label;
-        HT_TimestampNs start_ts;
-        HT_DurationNs duration;
-        std::vector<std::pair<TreeNode*, int>> children;
-        TreeNode* parent;
-        HT_DurationNs total_children_duration;
-
-        TreeNode(std::string name, HT_TimestampNs start, HT_DurationNs dur)
-        {
-            label = name;
-            start_ts = start;
-            duration = dur;
-            parent = nullptr;
-            total_children_duration = 0u;
-        }
-        
-        HT_TimestampNs get_stop_ts() const
-        {
-            return start_ts + duration;
-        }
-    };
-
     const std::string callgrind_header = "# callgrind format";
     std::string _file_name;
-    std::unordered_map<HT_ThreadId, TreeNode*> _calls;
-    std::unordered_map<HT_ThreadId, std::vector<std::pair<TreeNode*, int>>> _root_calls;
-    std::vector<std::pair<HT_ThreadId, TreeNode>> _events;
+    std::vector<std::pair<HT_ThreadId, CallGraph::TreeNode>> _events;
+    CallGraph _call_graph;
 
-    void _add_event(HT_ThreadId thread_id, 
-                    std::string label,
-                    HT_TimestampNs start_ts,
-                    HT_DurationNs duration);
-    void _add_new_calltree(HT_ThreadId thread_id, 
-                           std::string label,
-                           HT_TimestampNs start_ts,
-                           HT_DurationNs duration);
-    void _print_function(std::ofstream& file, TreeNode* node, std::string label);
+    void _print_function(std::ofstream& file, CallGraph::TreeNode* node, std::string label);
 };
 
 } // namespace client

--- a/client/callgrind_converter.hpp
+++ b/client/callgrind_converter.hpp
@@ -16,7 +16,6 @@ namespace client
 class CallgrindConverter : public Converter
 {
 public:
-    CallgrindConverter();
     ~CallgrindConverter() override;
 
     bool init(const std::string& file_name) override;
@@ -25,9 +24,6 @@ public:
     bool stop() override;
 
 private:
-    const std::string _mapping_klass_name; 
-    HT_EventKlassId _mapping_klass_id = 0;
- 
     struct TreeNode
     {
         std::string label;

--- a/client/callgrind_converter.hpp
+++ b/client/callgrind_converter.hpp
@@ -29,7 +29,7 @@ private:
     std::vector<std::pair<HT_ThreadId, CallGraph::TreeNode>> _events;
     CallGraph _call_graph;
 
-    void _print_function(std::ofstream& file, CallGraph::TreeNode* node, std::string label);
+    void _print_function(std::ofstream& file, std::shared_ptr<CallGraph::TreeNode> node, std::string label);
 };
 
 } // namespace client

--- a/client/callgrind_converter.hpp
+++ b/client/callgrind_converter.hpp
@@ -16,14 +16,56 @@ namespace client
 class CallgrindConverter : public Converter
 {
 public:
+    CallgrindConverter();
     ~CallgrindConverter() override;
 
     bool init(const std::string& file_name) override;
     void uninit() override;
     void process_event(const parser::Event& event) override;
+    bool stop() override;
 
 private:
-    std::ofstream _file;
+    const std::string _mapping_klass_name; 
+    HT_EventKlassId _mapping_klass_id = 0;
+ 
+    struct TreeNode
+    {
+        std::string label;
+        HT_TimestampNs start_ts;
+        HT_TimestampNs duration;
+        std::vector<std::pair<TreeNode*, int>> children;
+        TreeNode* father;
+        HT_TimestampNs total_children_duration;
+
+        TreeNode(std::string name, HT_TimestampNs start, HT_TimestampNs dur)
+        {
+            label = name;
+            start_ts = start;
+            duration = dur;
+            father = nullptr;
+            total_children_duration = 0u;
+        }
+        
+        HT_TimestampNs get_stop_ts()
+        {
+            return start_ts + duration;
+        }
+    };
+
+    std::string _file_name;
+    std::unordered_map<uint32_t, TreeNode*> _calls;
+    std::unordered_map<uint32_t, std::vector<std::pair<TreeNode*, int>>> _root_calls;
+    std::vector<std::pair<uint32_t, TreeNode>> _events;
+
+    void _add_event(uint32_t thread_id, 
+                    std::string label,
+                    HT_TimestampNs start_ts,
+                    HT_TimestampNs duration);
+    void _add_new_calltree(uint32_t thread_id, 
+                           std::string label,
+                           HT_TimestampNs start_ts,
+                           HT_TimestampNs duration);
+    void _print_function(std::ofstream& file, TreeNode* node, std::string label);
 };
 
 } // namespace client

--- a/client/callgrind_converter.hpp
+++ b/client/callgrind_converter.hpp
@@ -19,9 +19,8 @@ public:
     ~CallgrindConverter() override;
 
     bool init(const std::string& file_name) override;
-    void uninit() override;
     void process_event(const parser::Event& event) override;
-    bool stop() override;
+    void stop() override;
 
 private:
     const std::string callgrind_header = "# callgrind format";

--- a/client/callgrind_converter.hpp
+++ b/client/callgrind_converter.hpp
@@ -28,39 +28,40 @@ private:
     {
         std::string label;
         HT_TimestampNs start_ts;
-        HT_TimestampNs duration;
+        HT_DurationNs duration;
         std::vector<std::pair<TreeNode*, int>> children;
-        TreeNode* father;
-        HT_TimestampNs total_children_duration;
+        TreeNode* parent;
+        HT_DurationNs total_children_duration;
 
-        TreeNode(std::string name, HT_TimestampNs start, HT_TimestampNs dur)
+        TreeNode(std::string name, HT_TimestampNs start, HT_DurationNs dur)
         {
             label = name;
             start_ts = start;
             duration = dur;
-            father = nullptr;
+            parent = nullptr;
             total_children_duration = 0u;
         }
         
-        HT_TimestampNs get_stop_ts()
+        HT_TimestampNs get_stop_ts() const
         {
             return start_ts + duration;
         }
     };
 
+    const std::string callgrind_header = "# callgrind format";
     std::string _file_name;
-    std::unordered_map<uint32_t, TreeNode*> _calls;
-    std::unordered_map<uint32_t, std::vector<std::pair<TreeNode*, int>>> _root_calls;
-    std::vector<std::pair<uint32_t, TreeNode>> _events;
+    std::unordered_map<HT_ThreadId, TreeNode*> _calls;
+    std::unordered_map<HT_ThreadId, std::vector<std::pair<TreeNode*, int>>> _root_calls;
+    std::vector<std::pair<HT_ThreadId, TreeNode>> _events;
 
-    void _add_event(uint32_t thread_id, 
+    void _add_event(HT_ThreadId thread_id, 
                     std::string label,
                     HT_TimestampNs start_ts,
-                    HT_TimestampNs duration);
-    void _add_new_calltree(uint32_t thread_id, 
+                    HT_DurationNs duration);
+    void _add_new_calltree(HT_ThreadId thread_id, 
                            std::string label,
                            HT_TimestampNs start_ts,
-                           HT_TimestampNs duration);
+                           HT_DurationNs duration);
     void _print_function(std::ofstream& file, TreeNode* node, std::string label);
 };
 

--- a/client/callgrind_converter.hpp
+++ b/client/callgrind_converter.hpp
@@ -25,10 +25,9 @@ public:
 private:
     const std::string callgrind_header = "# callgrind format";
     std::string _file_name;
-    std::vector<std::pair<HT_ThreadId, CallGraph::NodeData>> _events;
-    CallGraph _call_graph;
+    std::unordered_map<HT_ThreadId, std::vector<CallGraph::NodeData>> _events;
 
-    void _print_function(std::ofstream& file, std::shared_ptr<CallGraph::TreeNode> node, std::string label);
+    void _print_function(std::ofstream& file, std::shared_ptr<CallGraph::TreeNode> node);
 };
 
 } // namespace client

--- a/client/chrome_trace_converter.cpp
+++ b/client/chrome_trace_converter.cpp
@@ -12,7 +12,6 @@ namespace client
 
 ChromeTraceConverter::~ChromeTraceConverter()
 {
-    uninit();
 }
 
 bool ChromeTraceConverter::init(const std::string& file_name)
@@ -24,15 +23,6 @@ bool ChromeTraceConverter::init(const std::string& file_name)
         return true;
     }
     return false;
-}
-
-void ChromeTraceConverter::uninit()
-{
-    if (_file.is_open())
-    {
-        _file << "]}";
-        _file.close();
-    }
 }
 
 void ChromeTraceConverter::process_event(const parser::Event& event)
@@ -53,10 +43,13 @@ void ChromeTraceConverter::process_event(const parser::Event& event)
          << "}";
 }
 
-bool ChromeTraceConverter::stop()
+void ChromeTraceConverter::stop()
 {
-    uninit();
-    return true;
+    if (_file.is_open())
+    {
+        _file << "]}";
+        _file.close();
+    }
 }
 
 } // namespace client

--- a/client/chrome_trace_converter.cpp
+++ b/client/chrome_trace_converter.cpp
@@ -39,8 +39,8 @@ void ChromeTraceConverter::process_event(const parser::Event& event)
     // so we need to convert from nano to micro
     _file << ",{\"name\": \"" << label
          << "\", \"ph\": \"X\", \"ts\": " << ns_to_ms(event.get_value<HT_TimestampNs>("timestamp"))
-         << ", \"dur\": " << ns_to_ms(event.get_timestamp())
-         << ", \"pid\": 0, \"tid\": " << event.get_value_or_default<HT_ThreadId>("thread_id", 0u)
+         << ", \"dur\": " << ns_to_ms(event.get_value_or_default<HT_DurationNs>("duration", 0u))
+         << ", \"pid\": 0, \"tid\": " << event.get_value_or_default<HT_ThreadId>("thread_id", 0)
          << "}";
 }
 

--- a/client/chrome_trace_converter.cpp
+++ b/client/chrome_trace_converter.cpp
@@ -94,5 +94,11 @@ void ChromeTraceConverter::process_event(const parser::Event& event)
          << "}";
 }
 
+bool ChromeTraceConverter::stop()
+{
+    uninit();
+    return true;
+}
+
 } // namespace client
 } // namespace HawkTracer

--- a/client/chrome_trace_converter.cpp
+++ b/client/chrome_trace_converter.cpp
@@ -38,9 +38,9 @@ void ChromeTraceConverter::process_event(const parser::Event& event)
     // Chrome expects the timestamps/durations to be microseconds
     // so we need to convert from nano to micro
     _file << ",{\"name\": \"" << label
-         << "\", \"ph\": \"X\", \"ts\": " << ns_to_ms(event.get_value<HT_TimestampNs>("timestamp"))
+         << "\", \"ph\": \"X\", \"ts\": " << ns_to_ms(event.get_timestamp())
          << ", \"dur\": " << ns_to_ms(event.get_value_or_default<HT_DurationNs>("duration", 0u))
-         << ", \"pid\": 0, \"tid\": " << event.get_value_or_default<HT_ThreadId>("thread_id", 0)
+         << ", \"pid\": 0, \"tid\": " << event.get_value_or_default<HT_ThreadId>("thread_id", 0u)
          << "}";
 }
 

--- a/client/chrome_trace_converter.cpp
+++ b/client/chrome_trace_converter.cpp
@@ -12,6 +12,7 @@ namespace client
 
 ChromeTraceConverter::~ChromeTraceConverter()
 {
+    stop();
 }
 
 bool ChromeTraceConverter::init(const std::string& file_name)

--- a/client/chrome_trace_converter.cpp
+++ b/client/chrome_trace_converter.cpp
@@ -38,6 +38,11 @@ void ChromeTraceConverter::uninit()
 void ChromeTraceConverter::process_event(const parser::Event& event)
 {
     std::string label = get_label(event);
+    
+    if (label == "")
+    {
+        return;
+    }
 
     // Chrome expects the timestamps/durations to be microseconds
     // so we need to convert from nano to micro

--- a/client/chrome_trace_converter.cpp
+++ b/client/chrome_trace_converter.cpp
@@ -1,7 +1,5 @@
 #include "chrome_trace_converter.hpp"
 
-#include "hawktracer/parser/klass_register.hpp"
-
 static uint64_t ns_to_ms(uint64_t nano_secs)
 {
     return nano_secs / 1000u;
@@ -11,11 +9,6 @@ namespace HawkTracer
 {
 namespace client
 {
-
-ChromeTraceConverter::ChromeTraceConverter() :
-    _mapping_klass_name("HT_StringMappingEvent")
-{
-}
 
 ChromeTraceConverter::~ChromeTraceConverter()
 {
@@ -44,46 +37,7 @@ void ChromeTraceConverter::uninit()
 
 void ChromeTraceConverter::process_event(const parser::Event& event)
 {
-    std::string label;
-
-    if (_mapping_klass_id == 0 &&
-            event.get_klass()->get_id() == HawkTracer::parser::to_underlying(HawkTracer::parser::WellKnownKlasses::EventKlassInfoEventKlass))
-    {
-        if (event.get_value<char*>("event_klass_name") == _mapping_klass_name)
-        {
-            _mapping_klass_id = event.get_value<HT_EventKlassId>("info_klass_id");
-        }
-    }
-    if (event.get_klass()->get_id() == _mapping_klass_id)
-    {
-        _tracepoint_map->add_map_entry(event.get_value<uint64_t>("identifier"), event.get_value<char*>("label"));
-        return;
-    }
-
-    if (event.has_value("label"))
-    {
-        const parser::Event::Value& value = event.get_raw_value("label");
-        if (value.field->get_type_id() == parser::FieldTypeId::UINT64)
-        {
-            label = _tracepoint_map->get_label_info(value.value.f_UINT64).label;
-        }
-        else if (value.field->get_type_id() == parser::FieldTypeId::STRING)
-        {
-            label = value.value.f_STRING;
-        }
-        else
-        {
-            label = "invalid label type";
-        }
-    }
-    else if (event.has_value("name"))
-    {
-        label = event.get_value<char*>("name");
-    }
-    else
-    {
-        return;
-    }
+    std::string label = get_label(event);
 
     // Chrome expects the timestamps/durations to be microseconds
     // so we need to convert from nano to micro

--- a/client/chrome_trace_converter.cpp
+++ b/client/chrome_trace_converter.cpp
@@ -39,8 +39,8 @@ void ChromeTraceConverter::process_event(const parser::Event& event)
     // so we need to convert from nano to micro
     _file << ",{\"name\": \"" << label
          << "\", \"ph\": \"X\", \"ts\": " << ns_to_ms(event.get_value<HT_TimestampNs>("timestamp"))
-         << ", \"dur\": " << ns_to_ms(event.get_value_or_default<HT_DurationNs>("duration", 0u))
-         << ", \"pid\": 0, \"tid\": " << event.get_value_or_default<HT_ThreadId>("thread_id", 0)
+         << ", \"dur\": " << ns_to_ms(event.get_timestamp())
+         << ", \"pid\": 0, \"tid\": " << event.get_value_or_default<HT_ThreadId>("thread_id", 0u)
          << "}";
 }
 

--- a/client/chrome_trace_converter.cpp
+++ b/client/chrome_trace_converter.cpp
@@ -37,7 +37,7 @@ void ChromeTraceConverter::uninit()
 
 void ChromeTraceConverter::process_event(const parser::Event& event)
 {
-    std::string label = get_label(event);
+    std::string label = _get_label(event);
     
     if (label == "")
     {
@@ -47,9 +47,9 @@ void ChromeTraceConverter::process_event(const parser::Event& event)
     // Chrome expects the timestamps/durations to be microseconds
     // so we need to convert from nano to micro
     _file << ",{\"name\": \"" << label
-         << "\", \"ph\": \"X\", \"ts\": " << ns_to_ms(event.get_value<uint64_t>("timestamp"))
-         << ", \"dur\": " << ns_to_ms(event.get_value_or_default<uint64_t>("duration", 0u))
-         << ", \"pid\": 0, \"tid\": " << event.get_value_or_default<uint32_t>("thread_id", 0)
+         << "\", \"ph\": \"X\", \"ts\": " << ns_to_ms(event.get_value<HT_TimestampNs>("timestamp"))
+         << ", \"dur\": " << ns_to_ms(event.get_value_or_default<HT_DurationNs>("duration", 0u))
+         << ", \"pid\": 0, \"tid\": " << event.get_value_or_default<HT_ThreadId>("thread_id", 0)
          << "}";
 }
 

--- a/client/chrome_trace_converter.hpp
+++ b/client/chrome_trace_converter.hpp
@@ -15,7 +15,6 @@ namespace client
 class ChromeTraceConverter : public Converter
 {
 public:
-    ChromeTraceConverter();
     ~ChromeTraceConverter() override;
 
     bool init(const std::string& file_name) override;
@@ -24,8 +23,6 @@ public:
     bool stop() override;
 
 private:
-    const std::string _mapping_klass_name; 
-    HT_EventKlassId _mapping_klass_id = 0;
     std::ofstream _file;
 };
 

--- a/client/chrome_trace_converter.hpp
+++ b/client/chrome_trace_converter.hpp
@@ -21,6 +21,7 @@ public:
     bool init(const std::string& file_name) override;
     void uninit() override;
     void process_event(const parser::Event& event) override;
+    bool stop() override;
 
 private:
     const std::string _mapping_klass_name; 

--- a/client/chrome_trace_converter.hpp
+++ b/client/chrome_trace_converter.hpp
@@ -18,9 +18,8 @@ public:
     ~ChromeTraceConverter() override;
 
     bool init(const std::string& file_name) override;
-    void uninit() override;
     void process_event(const parser::Event& event) override;
-    bool stop() override;
+    void stop() override;
 
 private:
     std::ofstream _file;

--- a/client/converter.cpp
+++ b/client/converter.cpp
@@ -3,7 +3,8 @@
 
 #include "converter.hpp"
 
-#include "hawktracer/parser/klass_register.hpp"
+#include <hawktracer/parser/klass_register.hpp>
+#include <hawktracer/parser/make_unique.hpp>
 #include <fstream>
 #include <stack>
 
@@ -13,9 +14,9 @@ namespace client
 {
 
 Converter::Converter() :
-    _mapping_klass_name("HT_StringMappingEvent")
+    _mapping_klass_name("HT_StringMappingEvent"),
+    _tracepoint_map(HawkTracer::parser::make_unique<TracepointMap>())
 {
-    _tracepoint_map = std::make_shared<TracepointMap>();
 }
 
 bool Converter::set_tracepoint_map(const std::string& map_files)

--- a/client/converter.cpp
+++ b/client/converter.cpp
@@ -11,6 +11,11 @@ namespace HawkTracer
 namespace client
 {
 
+Converter::Converter()
+{
+    _tracepoint_map = std::make_shared<TracepointMap>();
+}
+
 bool Converter::set_tracepoint_map(const std::string& map_files)
 {
     if (_tracepoint_map != nullptr)

--- a/client/converter.cpp
+++ b/client/converter.cpp
@@ -68,12 +68,10 @@ std::string Converter::_get_label(const parser::Event& event)
     if (_mapping_klass_id == 0)
     {
         _try_setting_mapping_klass_id(event);
-        label = "";
     }
     else if (event.get_klass()->get_id() == _mapping_klass_id)
     {
         _tracepoint_map->add_map_entry(event.get_value<uint64_t>("identifier"), event.get_value<char*>("label"));
-        label = "";
     } 
     else if (event.has_value("label"))
     {
@@ -82,10 +80,6 @@ std::string Converter::_get_label(const parser::Event& event)
     else if (event.has_value("name"))
     {
         label = event.get_value<char*>("name");
-    }
-    else
-    {
-        label = "";
     }
     return label;
 }

--- a/client/converter.cpp
+++ b/client/converter.cpp
@@ -3,6 +3,7 @@
 
 #include "converter.hpp"
 
+#include "hawktracer/parser/klass_register.hpp"
 #include <fstream>
 #include <stack>
 
@@ -11,7 +12,8 @@ namespace HawkTracer
 namespace client
 {
 
-Converter::Converter()
+Converter::Converter() :
+    _mapping_klass_name("HT_StringMappingEvent")
 {
     _tracepoint_map = std::make_shared<TracepointMap>();
 }
@@ -27,6 +29,50 @@ bool Converter::set_tracepoint_map(const std::string& map_files)
     {
         return false;
     }
+}
+
+std::string Converter::get_label(const parser::Event& event)
+{
+    std::string label;
+    if (_mapping_klass_id == 0 &&
+            event.get_klass()->get_id() == HawkTracer::parser::to_underlying(HawkTracer::parser::WellKnownKlasses::EventKlassInfoEventKlass))
+    {
+        if (event.get_value<char*>("event_klass_name") == _mapping_klass_name)
+        {
+            _mapping_klass_id = event.get_value<HT_EventKlassId>("info_klass_id");
+        }
+    }
+    if (event.get_klass()->get_id() == _mapping_klass_id)
+    {
+        _tracepoint_map->add_map_entry(event.get_value<uint64_t>("identifier"), event.get_value<char*>("label"));
+        return label;
+    }
+
+    if (event.has_value("label"))
+    {
+        const parser::Event::Value& value = event.get_raw_value("label");
+        if (value.field->get_type_id() == parser::FieldTypeId::UINT64)
+        {
+            label = _tracepoint_map->get_label_info(value.value.f_UINT64).label;
+        }
+        else if (value.field->get_type_id() == parser::FieldTypeId::STRING)
+        {
+            label = value.value.f_STRING;
+        }
+        else
+        {
+            label = "invalid label type";
+        }
+    }
+    else if (event.has_value("name"))
+    {
+        label = event.get_value<char*>("name");
+    }
+    else
+    {
+        return label;
+    }
+    return label;
 }
 
 } // namespace client

--- a/client/converter.cpp
+++ b/client/converter.cpp
@@ -45,20 +45,15 @@ void Converter::_try_setting_mapping_klass_id(const parser::Event& event)
 
 std::string Converter::_convert_value_to_string(const parser::Event::Value& value)
 {
-    std::string label;
-    if (value.field->get_type_id() == parser::FieldTypeId::UINT64)
+    switch (value.field->get_type_id())
     {
-        label = _tracepoint_map->get_label_info(value.value.f_UINT64).label;
+    case parser::FieldTypeId::UINT64:
+        return _tracepoint_map->get_label_info(value.value.f_UINT64).label;
+    case parser::FieldTypeId::STRING:
+        return value.value.f_STRING;
+    default:
+        return "invalid label type";
     }
-    else if (value.field->get_type_id() == parser::FieldTypeId::STRING)
-    {
-        label = value.value.f_STRING;
-    }
-    else
-    {
-        label = "invalid label type";
-    }
-    return label;
 }
 
 std::string Converter::_get_label(const parser::Event& event)

--- a/client/converter.hpp
+++ b/client/converter.hpp
@@ -26,10 +26,14 @@ public:
     virtual bool stop() = 0;
 
 protected:
-    std::string get_label(const parser::Event& event);
+    std::string _get_label(const parser::Event& event);
+    std::unique_ptr<TracepointMap> _tracepoint_map;
+
+private:
+    void _try_setting_mapping_klass_id(const parser::Event& event);
+    std::string _convert_value_to_string(const parser::Event::Value& value);
     const std::string _mapping_klass_name; 
     HT_EventKlassId _mapping_klass_id = 0;
-    std::unique_ptr<TracepointMap> _tracepoint_map;
 };
 
 } // namespace client

--- a/client/converter.hpp
+++ b/client/converter.hpp
@@ -24,6 +24,8 @@ public:
 
 protected:
     Converter();
+    std::string get_label(const parser::Event& event);
+    const std::string _mapping_klass_name; 
     HT_EventKlassId _mapping_klass_id = 0;
     std::shared_ptr<TracepointMap> _tracepoint_map;
 };

--- a/client/converter.hpp
+++ b/client/converter.hpp
@@ -17,6 +17,7 @@ class Converter
 public:
     Converter();
 
+
     virtual ~Converter() {}
     virtual bool init(const std::string& file_name) = 0;
     virtual void uninit() = 0;
@@ -25,7 +26,6 @@ public:
     virtual bool stop() = 0;
 
 protected:
-    Converter();
     std::string get_label(const parser::Event& event);
     const std::string _mapping_klass_name; 
     HT_EventKlassId _mapping_klass_id = 0;

--- a/client/converter.hpp
+++ b/client/converter.hpp
@@ -20,10 +20,9 @@ public:
 
     virtual ~Converter() {}
     virtual bool init(const std::string& file_name) = 0;
-    virtual void uninit() = 0;
     virtual void process_event(const parser::Event& event) = 0;
     bool set_tracepoint_map(const std::string& map_files);
-    virtual bool stop() = 0;
+    virtual void stop() = 0;
 
 protected:
     std::string _get_label(const parser::Event& event);

--- a/client/converter.hpp
+++ b/client/converter.hpp
@@ -20,8 +20,10 @@ public:
     virtual void uninit() = 0;
     virtual void process_event(const parser::Event& event) = 0;
     bool set_tracepoint_map(const std::string& map_files);
+    virtual bool stop() = 0;
 
 protected:
+    Converter();
     HT_EventKlassId _mapping_klass_id = 0;
     std::shared_ptr<TracepointMap> _tracepoint_map;
 };

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -148,8 +148,15 @@ int main(int argc, char** argv)
     else
     {
         auto& converter = formats[format];
-        converter->init(out_file);
-        reader.register_events_listener([&converter] (const parser::Event& event) { converter->process_event(event); });
+        if (converter->init(out_file))
+        {
+            reader.register_events_listener([&converter] (const parser::Event& event) { converter->process_event(event); });
+        }
+        else
+        {
+            std::cerr << "Can't open output file" << std::endl;
+            return 1;
+        }
     }
 
     if (map_files.empty())
@@ -186,15 +193,6 @@ int main(int argc, char** argv)
 
     reader.wait_for_complete();
     reader.stop();
-    bool conversion_completed = formats[format]->stop();
-
-    if (conversion_completed)
-    {
-        std::cout << "Trace file has been saved to: " << out_file << std::endl;
-    }
-    else
-    {
-        std::cerr << "Error on completing conversion" << std::endl;
-    }
+    formats[format]->stop();
     return 0;
 }

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -192,8 +192,15 @@ int main(int argc, char** argv)
 
     reader.wait_for_complete();
     reader.stop();
+    bool conversion_completed = formats[format]->stop();
 
-    std::cout << "Trace file has been saved to: " << out_file << std::endl;
-
+    if (conversion_completed)
+    {
+        std::cout << "Trace file has been saved to: " << out_file << std::endl;
+    }
+    else
+    {
+        std::cerr << "Error on completing conversion" << std::endl;
+    }
     return 0;
 }

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -8,7 +8,6 @@
 #include <iostream>
 #include <cstring>
 #include <map>
-#include <unistd.h>
 
 using namespace HawkTracer;
 
@@ -146,18 +145,14 @@ int main(int argc, char** argv)
         std::cerr << "Unknown format: " << format << ". Supported formats are: " << supported_formats(formats) << std::endl;
         return 1;
     }
+    if (converter->second->init(out_file))
+    {
+        reader.register_events_listener([&converter] (const parser::Event& event) { converter->second->process_event(event); });
+    }
     else
     {
-        auto& converter = formats[format];
-        if (converter->init(out_file))
-        {
-            reader.register_events_listener([&converter] (const parser::Event& event) { converter->process_event(event); });
-        }
-        else
-        {
-            std::cerr << "Can't open output file" << std::endl;
-            return 1;
-        }
+        std::cerr << "Can't open output file" << std::endl;
+        return 1;
     }
 
     if (map_files.empty())

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <cstring>
 #include <map>
+#include <unistd.h>
 
 using namespace HawkTracer;
 
@@ -193,6 +194,8 @@ int main(int argc, char** argv)
 
     reader.wait_for_complete();
     reader.stop();
-    formats[format]->stop();
+    converter->second->stop();
+
     return 0;
+
 }

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -150,12 +150,6 @@ int main(int argc, char** argv)
         auto& converter = formats[format];
         converter->init(out_file);
         reader.register_events_listener([&converter] (const parser::Event& event) { converter->process_event(event); });
-
-        // CallgringConverter not fully implemented
-        if (format == "callgrind")
-        {
-            std::cout << "Support for callgrind format is not implemented yet!!!" << std::endl;
-        }
     }
 
     if (map_files.empty())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Converter base class is getting an event's label.
Callgrind Converter firstly stores all the events and then starts the actual conversion to callgrind format. It keeps for each thread the roots of all traced calls and it builds the call graph. 
I'll add tests for this in a different PR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
