### PR TITLE
Fixed windows compilation

### DIFF
--- a/lib/include/hawktracer/macros.h
+++ b/lib/include/hawktracer/macros.h
@@ -20,7 +20,7 @@
 #  define HT_DECLS_END
 #endif
 
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
 #  define HT_CPP11
 #endif
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
VisualStudio doesn't respect the __cplusplus for a long time so this change is needed in order to compile on a lot of versions.
https://blogs.msdn.microsoft.com/vcblog/2018/04/09/msvc-now-correctly-reports-__cplusplus/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
