### PR TITLE
Added tests for call_graph used by callgrind converter

### DIFF
--- a/client/call_graph.cpp
+++ b/client/call_graph.cpp
@@ -75,7 +75,7 @@ bool CallGraph::_try_add_event_to_existing_calltree(const NodeData& node_data)
         }
         else 
         {
-            _current_call = _current_call->parent;
+            _current_call = _current_call->parent.lock();
         }
     }
     return false;

--- a/client/call_graph.hpp
+++ b/client/call_graph.hpp
@@ -42,7 +42,7 @@ public:
         HT_DurationNs total_children_duration;
 
         std::vector<std::pair<std::shared_ptr<TreeNode>, int>> children;
-        std::shared_ptr<TreeNode> parent;
+        std::weak_ptr<TreeNode> parent;
 
         TreeNode(NodeData node_data)
         {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,3 +48,4 @@ endfunction(DEFINE_HT_TEST)
 
 add_subdirectory(lib)
 add_subdirectory(parser)
+add_subdirectory(client)

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(hawktracer_client_tests
     main_tests.cpp
     test_call_graph.cpp
+    test_file_loader.cpp
     test_path.cpp)
     
 file(COPY test_multiple_calls.txt

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(hawktracer_client_tests
+    main_tests.cpp
+    test_call_graph.cpp
+    test_path.cpp)
+    
+file(COPY test_multiple_calls.txt
+          test_3_lvls_stack_simple_calls.txt 
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+DEFINE_HT_TEST(NAME client
+    SOURCES ${hawktracer_client_tests}
+    LINK_LIBS ${GTEST_LIBRARY} hawktracer_client
+    RUN_PARAMS --gtest_output=xml:hawktracer_client_tests.xml)

--- a/tests/client/main_tests.cpp
+++ b/tests/client/main_tests.cpp
@@ -1,0 +1,19 @@
+#include "test_path.hpp"
+
+#include <gtest/gtest.h>
+
+#include <hawktracer/init.h>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    TestPath::get().set_application_path(argv[0]);
+
+    ht_init(argc, argv);
+
+    auto ret = RUN_ALL_TESTS();
+
+    ht_deinit();
+
+    return ret;
+}

--- a/tests/client/test_3_lvls_stack_simple_calls.txt
+++ b/tests/client/test_3_lvls_stack_simple_calls.txt
@@ -1,0 +1,30 @@
+7
+#ID   LABEL   CNT_CALLS   LAST_START_TS   LAST_STOP_TS   TOTAL_DUR   TOTAL_CHILDREN_DUR
+1      root           1               0           1300        1300                 1000
+2      fnc1           0             100            600         500                  200
+3      fnc2           0             700           1200         500                  200
+4      fnc3           0             200            300         100                    0
+5      fnc4           0             400            500         100                    0
+6      fnc5           0             800            900         100                    0
+7      fnc6           0            1000           1100         100                    0
+
+7
+#ID   PARENT_ID   CNT_CHILDREN   (CHILD_ID, CNT_CALLS)
+1             0              2    2 1   3 1
+2             1              2    4 1   5 1 
+3             1              2    6 1   7 1
+4             2              0
+5             2              0
+6             3              0
+7             3              0
+
+7
+#LABEL   START_TS   DURATION
+root            0       1300
+fnc1          100        500
+fnc2          700        500
+fnc3          200        100
+fnc4          400        100
+fnc5          800        100
+fnc6         1000        100
+

--- a/tests/client/test_3_lvls_stack_simple_calls.txt
+++ b/tests/client/test_3_lvls_stack_simple_calls.txt
@@ -1,3 +1,36 @@
+# This file contains information about the expected call tree that CallGraph should build for
+# a specific sequence of events.
+#
+#
+# Each block is being proceded by the the number of lines it contains.
+#
+#
+# First block describes the expected node data. Each node has
+# ID - unique id
+# LABEL - event's label
+# CNT_CALLS - number of times this node is called if it's root
+# LAST_START_TS - the start time of the last call
+# LAST_STOP_TS - the end time of the last call
+# TOTAL_DUR - sum of durations of all calls 
+# TOTAL_CHILDREN_DUR - total duration of its children
+#
+#
+# Second block describes the edges between these nodes. They need to form a tree
+# ID - unique id of the node being described
+# PARENT_ID - unique id of the parent of the node
+# CNT_CHILDREN - number of children 
+# (CHILD_ID, CNT_CALLS) - sequence of pairs describing the children; they need to be in 
+#                         the order you expect CallGraph to build (increasing order by
+#                         their first start time)
+#       CHILD_ID - unique id of the child
+#       CNT_CALLS - total number of times it is being called by parent
+#
+#
+# Third block describes the sequence of events that you are passing to CallGraph.make()
+# LABEL - event's label
+# START_TS - start event time
+# DURATION - event's duration
+   
 7
 #ID   LABEL   CNT_CALLS   LAST_START_TS   LAST_STOP_TS   TOTAL_DUR   TOTAL_CHILDREN_DUR
 1      root           1               0           1300        1300                 1000
@@ -7,7 +40,7 @@
 5      fnc4           0             400            500         100                    0
 6      fnc5           0             800            900         100                    0
 7      fnc6           0            1000           1100         100                    0
-
+   
 7
 #ID   PARENT_ID   CNT_CHILDREN   (CHILD_ID, CNT_CALLS)
 1             0              2    2 1   3 1

--- a/tests/client/test_call_graph.cpp
+++ b/tests/client/test_call_graph.cpp
@@ -1,0 +1,233 @@
+#include "test_path.hpp"
+#include <client/call_graph.hpp>
+
+#include <gtest/gtest.h>
+
+#include <queue>
+#include <fstream>
+#include <iostream>
+
+using HawkTracer::client::CallGraph;
+
+::testing::AssertionResult SameTree(const std::pair<std::shared_ptr<CallGraph::TreeNode>, int>& expected, 
+                                    const std::pair<std::shared_ptr<CallGraph::TreeNode>, int>& actual)
+{
+    if (expected.second != actual.second)
+    {
+        return ::testing::AssertionFailure() << std::endl
+            << "Expected calls to root: " << expected.second << std::endl
+            << "Actual calls to root: " << actual.second << std::endl;
+    }
+
+    std::queue<std::shared_ptr<CallGraph::TreeNode>> actual_fnc_queue;
+    std::queue<std::shared_ptr<CallGraph::TreeNode>> expected_fnc_queue;
+    actual_fnc_queue.push(actual.first); 
+    expected_fnc_queue.push(expected.first);
+
+    while (!actual_fnc_queue.empty())
+    {
+        auto& actual_fnc = actual_fnc_queue.front();
+        auto& expected_fnc = expected_fnc_queue.front();
+
+        if (expected_fnc->data.label != actual_fnc->data.label)
+        {
+            return ::testing::AssertionFailure() << std::endl 
+                << "Expected label: " << expected_fnc->data.label << std::endl
+                << "Actual label: " << actual_fnc->data.label << std::endl;
+
+        }
+        if (expected_fnc->data.start_ts != actual_fnc->data.start_ts)
+        {
+            return ::testing::AssertionFailure() << std::endl 
+                << "For node with label: " << expected_fnc->data.label << std::endl
+                << "Expected start_ts: " << expected_fnc->data.start_ts << std::endl
+                << "Actual start_ts: " << actual_fnc->data.start_ts << std::endl;
+        }
+        if (expected_fnc->data.stop_ts  != actual_fnc->data.stop_ts)
+        {
+            return ::testing::AssertionFailure() << std::endl 
+                << "For node with label: " << expected_fnc->data.label << std::endl
+                << "Expected stop_ts: " << expected_fnc->data.stop_ts << std::endl
+                << "Actual stop_ts: " << actual_fnc->data.stop_ts << std::endl;
+        }
+        
+        if (expected_fnc->children.size() != actual_fnc->children.size())
+        {
+            return ::testing::AssertionFailure() << std::endl 
+                << "For node with label: " << expected_fnc->data.label << std::endl
+                << "Expected number of children: " << expected_fnc->children.size() << std::endl
+                << "Actual number of children: " << actual_fnc->children.size() << std::endl;
+        }
+
+        for (size_t i = 0; i < actual_fnc->children.size(); ++i)
+        {
+            if (expected_fnc->children[i].second != actual_fnc->children[i].second) 
+            {
+                return ::testing::AssertionFailure() << std::endl
+                    << "For node with label: " << expected_fnc->data.label << std::endl
+                    << "Expected number of calls to a child: " << expected_fnc->children[i].second << std::endl
+                    << "Actual number of calls to a child: " << actual_fnc->children[i].second << std::endl;
+            }
+
+            actual_fnc_queue.push(actual_fnc->children[i].first);
+            expected_fnc_queue.push(expected_fnc->children[i].first);
+        }
+
+        actual_fnc_queue.pop();
+        expected_fnc_queue.pop();
+    }
+
+    return ::testing::AssertionSuccess();
+}
+
+void init(std::vector<CallGraph::NodeData>& events,
+        std::vector<std::pair<std::shared_ptr<CallGraph::TreeNode>, int>>& tree,
+        std::string file_name)
+{
+    std::ifstream file;
+    file.open(file_name);
+    if (file.is_open())
+    {
+        std::string line;
+        std::unordered_map<unsigned int, std::pair<std::shared_ptr<CallGraph::TreeNode>, unsigned int>> nodes;
+
+        // Read tree nodes
+        size_t cnt_lines;
+        file >> cnt_lines;
+        file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        std::getline(file, line);
+
+        // ID LABEL CNT_CALLS LAST_START_TS LAST_STOP_TS TOTAL_DUR TOTAL_CHILDREN_DUR
+        for (size_t i = 0; i < cnt_lines; ++i) 
+        {
+            unsigned int id;
+            std::string label;
+            unsigned int cnt_calls;
+            HT_TimestampNs last_start_ts;
+            HT_TimestampNs last_stop_ts;
+            HT_DurationNs total_dur;
+            HT_DurationNs total_children_dur;
+
+            file >> id >> label >> cnt_calls >> last_start_ts >> last_stop_ts >> total_dur >> total_children_dur; 
+
+            std::shared_ptr<CallGraph::TreeNode> node = 
+                std::make_shared<CallGraph::TreeNode>(CallGraph::NodeData(label, last_start_ts, last_stop_ts - last_start_ts));
+            node->total_children_duration = total_children_dur;
+            node->total_duration = total_dur;
+            nodes[id] = make_pair(node, cnt_calls);
+
+        }
+
+        // Read tree edges
+        file >> cnt_lines;
+        file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        std::getline(file, line);
+
+        // ID  PARENT_ID  CNT_CHILDREN (CHILD_ID, CNT_CALLS)
+        for (size_t i = 0; i < cnt_lines; ++i)
+        {
+            unsigned int id;
+            unsigned int parent_id;
+            unsigned int cnt_children;
+
+            file >> id >> parent_id >> cnt_children;
+
+            if (parent_id == 0)
+            {
+                tree.emplace_back(nodes[id].first, nodes[id].second);
+            }
+
+            else
+            {
+                nodes[id].first->parent = nodes[parent_id].first;
+            }
+            for (size_t i = 0; i < cnt_children; ++i)
+            {
+                unsigned int child_id;
+                unsigned int cnt_calls;
+
+                file >> child_id >> cnt_calls;
+                nodes[id].first->children.emplace_back(nodes[child_id].first, cnt_calls);
+            }
+
+        }
+
+        // Read events data
+        file >> cnt_lines;
+        file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        std::getline(file, line);
+
+        // LABEL   START_TS   DURATION
+        for (size_t i = 0; i < cnt_lines; ++i)
+        { 
+            std::string label;
+            HT_TimestampNs start_ts = 0;
+            HT_DurationNs dur = 0;
+
+            file >> label >> start_ts >> dur;
+
+            events.emplace_back(label, start_ts, dur);
+        }
+    }
+
+    else
+    {
+        std::cout << "File not open\n";
+    }
+}
+
+TEST(TestCallGraph, EmptyVectorOfEventShouldReturnEmptyGraph)
+{
+    // Arrange
+    std::vector<CallGraph::NodeData> events;
+    CallGraph call_graph;
+
+    // Act
+    auto response = call_graph.make(events);
+
+    // Assert
+    ASSERT_TRUE(response.empty());
+}
+
+
+TEST(TestCallGraph, Test3LevelsCallStackWithSimpleCalls)
+{
+    // Arrange
+    std::vector<CallGraph::NodeData> events;
+    std::vector<std::pair<std::shared_ptr<CallGraph::TreeNode>, int>> correct_response;
+    init(events, correct_response, TestPath::get().get_input_file_path("test_3_lvls_stack_simple_calls.txt"));
+
+    CallGraph call_graph;
+
+    // Act
+    auto response = call_graph.make(events);
+
+    // Assert
+    ASSERT_EQ(correct_response.size(), response.size());
+    for (size_t i = 0; i < correct_response.size(); ++i)
+    {
+        ASSERT_TRUE(SameTree(correct_response[i], response[i]));
+    }
+}
+
+TEST(TestCallGraph, TestMultpleCalls)
+{
+    // Arrange
+    std::vector<CallGraph::NodeData> events;
+    std::vector<std::pair<std::shared_ptr<CallGraph::TreeNode>, int>> correct_response;
+    init(events, correct_response, TestPath::get().get_input_file_path("test_multiple_calls.txt"));
+
+    CallGraph call_graph;
+
+    // Act
+    auto response = call_graph.make(events);
+
+    // Assert
+    ASSERT_EQ(correct_response.size(), response.size());
+    for (size_t i = 0; i < correct_response.size(); ++i)
+    {
+        ASSERT_TRUE(SameTree(correct_response[i], response[i]));
+    }
+}
+
+

--- a/tests/client/test_file_loader.cpp
+++ b/tests/client/test_file_loader.cpp
@@ -24,7 +24,6 @@ std::vector<std::pair<std::shared_ptr<CallGraph::TreeNode>, int>> TestFileLoader
 std::string TestFileLoader::_next_valid_line()
 {
     std::string line;
-    std::getline(_file, line);
     while (std::getline(_file, line))
     {
         if (!(line[0] == '#' || line.find_first_not_of(" \n") == std::string::npos))

--- a/tests/client/test_file_loader.cpp
+++ b/tests/client/test_file_loader.cpp
@@ -1,0 +1,124 @@
+#include "test_file_loader.hpp"
+#include <sstream>
+
+bool TestFileLoader::init(std::string file_name)
+{
+    _file.open(file_name);
+    if (_file.is_open())
+    {
+        _parse_file();
+    }
+    return _file.is_open();
+}
+
+std::vector<CallGraph::NodeData> TestFileLoader::get_events()
+{
+    return _events;
+}
+
+std::vector<std::pair<std::shared_ptr<CallGraph::TreeNode>, int>> TestFileLoader::get_tree()
+{
+    return _tree;
+}
+
+std::string TestFileLoader::_next_valid_line()
+{
+    std::string line;
+    std::getline(_file, line);
+    while (std::getline(_file, line))
+    {
+        if (!(line[0] == '#' || line.find_first_not_of(" \n") == std::string::npos))
+        {
+            break;
+        }
+    }
+    return line;
+}
+
+void TestFileLoader::_read_tree_nodes()
+{
+    size_t cnt_lines = stoi(_next_valid_line());
+
+    // ID LABEL CNT_CALLS LAST_START_TS LAST_STOP_TS TOTAL_DUR TOTAL_CHILDREN_DUR
+    for (size_t i = 0; i < cnt_lines; ++i) 
+    {
+        std::stringstream line_stream(_next_valid_line());
+        unsigned int id;
+        std::string label;
+        unsigned int cnt_calls;
+        HT_TimestampNs last_start_ts;
+        HT_TimestampNs last_stop_ts;
+        HT_DurationNs total_dur;
+        HT_DurationNs total_children_dur;
+
+        line_stream >> id >> label >> cnt_calls >> last_start_ts >> last_stop_ts >> total_dur >> total_children_dur; 
+
+        std::shared_ptr<CallGraph::TreeNode> node = 
+            std::make_shared<CallGraph::TreeNode>(CallGraph::NodeData(label, last_start_ts, last_stop_ts - last_start_ts));
+        node->total_children_duration = total_children_dur;
+        node->total_duration = total_dur;
+        _nodes[id] = make_pair(node, cnt_calls);
+    }
+}
+
+void TestFileLoader::_read_tree_edges()
+{
+    size_t cnt_lines = stoi(_next_valid_line());
+
+    // ID  PARENT_ID  CNT_CHILDREN (CHILD_ID, CNT_CALLS)
+    for (size_t i = 0; i < cnt_lines; ++i)
+    {
+        std::stringstream line_stream(_next_valid_line());
+        unsigned int id;
+        unsigned int parent_id;
+        unsigned int cnt_children;
+
+        line_stream >> id >> parent_id >> cnt_children;
+
+        if (parent_id == 0)
+        {
+            _tree.emplace_back(_nodes[id].first, _nodes[id].second);
+        }
+        else
+        {
+            _nodes[id].first->parent = _nodes[parent_id].first;
+        }
+        for (size_t i = 0; i < cnt_children; ++i)
+        {
+            unsigned int child_id;
+            unsigned int cnt_calls;
+
+            line_stream >> child_id >> cnt_calls;
+            _nodes[id].first->children.emplace_back(_nodes[child_id].first, cnt_calls);
+        }
+    }
+}
+
+void TestFileLoader::_read_events_data()
+{
+    std::string blank_line;
+    size_t cnt_lines = stoi(_next_valid_line());
+
+    // LABEL   START_TS   DURATION
+    for (size_t i = 0; i < cnt_lines; ++i)
+    { 
+        std::stringstream line_stream(_next_valid_line());
+        std::string label;
+        HT_TimestampNs start_ts = 0;
+        HT_DurationNs dur = 0;
+
+        line_stream >> label >> start_ts >> dur;
+
+        _events.emplace_back(label, start_ts, dur);
+    }
+}
+
+void TestFileLoader::_parse_file()
+{
+
+    _read_tree_nodes();
+    _read_tree_edges();
+    _read_events_data();
+
+    // Read events data
+}

--- a/tests/client/test_file_loader.hpp
+++ b/tests/client/test_file_loader.hpp
@@ -1,0 +1,29 @@
+#ifndef HT_TEST_CLIENT_TESTFILELOADER_HPP
+#define HT_TEST_CLIENT_TESTFILELOADER_HPP
+
+#include <client/call_graph.hpp>
+#include <fstream>
+
+using HawkTracer::client::CallGraph;
+
+class TestFileLoader
+{
+public:
+    bool init(std::string file_name); 
+    std::vector<CallGraph::NodeData> get_events();
+    std::vector<std::pair<std::shared_ptr<CallGraph::TreeNode>, int>> get_tree();
+
+private:
+    std::string _next_valid_line();
+    void _read_tree_nodes();
+    void _read_tree_edges();
+    void _read_events_data();
+    void _parse_file();
+
+    std::ifstream _file;
+    std::unordered_map<unsigned int, std::pair<std::shared_ptr<HawkTracer::client::CallGraph::TreeNode>, unsigned int>> _nodes;
+    std::vector<CallGraph::NodeData> _events;
+    std::vector<std::pair<std::shared_ptr<CallGraph::TreeNode>, int>> _tree;
+};
+
+#endif //HT_TEST_CLIENT_TESTFILELOADER_HPP

--- a/tests/client/test_multiple_calls.txt
+++ b/tests/client/test_multiple_calls.txt
@@ -1,0 +1,31 @@
+5
+#ID   LABEL   CNT_CALLS   LAST_START_TS   LAST_STOP_TS   TOTAL_DUR   TOTAL_CHILDREN_DUR
+1      root           2            1100           2000        1900                 1100
+2      fnc1           0             500            700         500                  180
+3      fnc2           0             800            900         100                    0
+4      fnc3           0             650            680         180                    0
+5      fnc3           0            1500           1800         500                    0
+
+5
+#ID   PARENT_ID   CNT_CHILDREN    (CHILD_ID, CNT_CALLS)
+1             0              3     2 2   3 1   5 2
+2             1              1     4 3
+3             1              0 
+4             2              0
+5             1              0
+
+10
+#LABEL   START_TS   DURATION
+root            0       1000
+root         1100        900
+fnc1          100        300
+fnc1          500        200
+fnc3          200        100
+fnc3          550         50
+fnc3          650         30
+fnc3         1200        200
+fnc3         1500        300
+fnc2          800        100
+
+
+

--- a/tests/client/test_multiple_calls.txt
+++ b/tests/client/test_multiple_calls.txt
@@ -1,3 +1,36 @@
+# This file contains information about the expected call tree that CallGraph should build for
+# a specific sequence of events.
+#
+#
+# Each block is being proceded by the the number of lines it contains.
+#
+#
+# First block describes the expected node data. Each node has
+# ID - unique id
+# LABEL - event's label
+# CNT_CALLS - number of times this node is called if it's root
+# LAST_START_TS - the start time of the last call
+# LAST_STOP_TS - the end time of the last call
+# TOTAL_DUR - sum of durations of all calls 
+# TOTAL_CHILDREN_DUR - total duration of its children
+#
+#
+# Second block describes the edges between these nodes. They need to form a tree
+# ID - unique id of the node being described
+# PARENT_ID - unique id of the parent of the node
+# CNT_CHILDREN - number of children 
+# (CHILD_ID, CNT_CALLS) - sequence of pairs describing the children; they need to be in 
+#                         the order you expect CallGraph to build (increasing order by
+#                         their first start time)
+#       CHILD_ID - unique id of the child
+#       CNT_CALLS - total number of times it is being called by parent
+#
+#
+# Third block describes the sequence of events that you are passing to CallGraph.make()
+# LABEL - event's label
+# START_TS - start event time
+# DURATION - event's duration
+
 5
 #ID   LABEL   CNT_CALLS   LAST_START_TS   LAST_STOP_TS   TOTAL_DUR   TOTAL_CHILDREN_DUR
 1      root           2            1100           2000        1900                 1100
@@ -26,6 +59,4 @@ fnc3          650         30
 fnc3         1200        200
 fnc3         1500        300
 fnc2          800        100
-
-
 

--- a/tests/client/test_path.cpp
+++ b/tests/client/test_path.cpp
@@ -3,6 +3,12 @@
 
 #include "test_path.hpp"
 
+#ifdef _WIN32
+#define PATH_SEPARATOR "\\"
+#else
+#define PATH_SEPARATOR "/"
+#endif
+
 TestPath::TestPath()
 {
 }
@@ -15,7 +21,7 @@ TestPath& TestPath::get()
 
 void TestPath::set_application_path(const std::string& app_path)
 {
-    size_t pos = app_path.rfind('/');
+    size_t pos = app_path.rfind(PATH_SEPARATOR);
     if (pos != std::string::npos)
     {
         _tests_dir= app_path.substr(0, pos + 1);

--- a/tests/client/test_path.cpp
+++ b/tests/client/test_path.cpp
@@ -1,0 +1,30 @@
+#ifndef HT_TEST_CLIENT_TESTPATH_CPP
+#define HT_TEST_CLIENT_TESTPATH_CPP
+
+#include "test_path.hpp"
+
+TestPath::TestPath()
+{
+}
+
+TestPath& TestPath::get()
+{
+    static TestPath test_path;
+    return test_path;
+}
+
+void TestPath::set_application_path(const std::string& app_path)
+{
+    size_t pos = app_path.rfind('/');
+    if (pos != std::string::npos)
+    {
+        _tests_dir= app_path.substr(0, pos + 1);
+    }
+}
+
+std::string TestPath::get_input_file_path(const std::string& file_name)
+{
+    return _tests_dir + file_name;
+}
+
+#endif //HT_TEST_CLIENT_TESTPATH_CPP

--- a/tests/client/test_path.hpp
+++ b/tests/client/test_path.hpp
@@ -1,0 +1,23 @@
+#ifndef HT_TEST_CLIENT_TESTPATH_HPP
+#define HT_TEST_CLIENT_TESTPATH_HPP
+
+#include <string>
+
+class TestPath
+{
+public:
+    TestPath(TestPath&) = delete;
+    TestPath& operator=(TestPath&) = delete;
+
+    static TestPath& get();
+
+    void set_application_path(const std::string& app_path);
+    std::string get_input_file_path(const std::string& file_name);
+
+private:
+    TestPath();
+    std::string _tests_dir;
+};
+
+#endif //HT_TEST_CLIENT_TESTPATH_HPP
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The tests inputs are kept in separate files. There are 3 parts to each file:
1) describe the tree nodes as you expect them 
2) describe the relations between them (order of children matters)
3) describe the events that are being passed to CallGraph.make(..)
Each part is preceded by its size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
