### PR TITLE
[doc] fix usage of deprecated macros in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The tutorial step by step explains how to build and instrument the code like tha
 ```cpp
 static void hello_world()
 {
-    HT_TP_G_FUNCTION()
+    HT_G_TRACE_FUNCTION()
 
     for (int i = 0; i < 100; i++)
     {


### PR DESCRIPTION
*Issue #, if available:*
none

*Description of changes:*
In an example in README.md, the deprecated macro HT_TP_G_FUNCTION is used. This pull request changes this to HT_G_TRACE_FUNCTION.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
