### PR TITLE
[lib] Build amalgamation libs same type as hawktracer lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,6 @@ if(ENABLE_RELEASE_MODE)
 endif(ENABLE_RELEASE_MODE)
 
 include(warnings)
-include(test_amalgamation)
 
 if(ENABLE_ASAN)
     include(asan)
@@ -84,6 +83,8 @@ if(BUILD_STATIC_LIB)
 else ()
     set(HAWKTRACER_LIB_TYPE SHARED)
 endif(BUILD_STATIC_LIB)
+
+include(test_amalgamation)
 
 add_subdirectory(lib)
 

--- a/cmake/test_amalgamation.cmake
+++ b/cmake/test_amalgamation.cmake
@@ -12,12 +12,12 @@ if(${PYTHONINTERP_FOUND})
     add_custom_command(OUTPUT hawktracer.c
         COMMAND ${PYTHON_EXECUTABLE} ARGS ${AMALGAMATION_ARGS} VERBATIM)
 
-    add_library(amalgamated_hawktracer_c SHARED
+    add_library(amalgamated_hawktracer_c ${HAWKTRACER_LIB_TYPE}
         hawktracer.c)
 
     add_custom_command(OUTPUT hawktracer.cpp
         COMMAND ${PYTHON_EXECUTABLE} ARGS ${AMALGAMATION_ARGS_CPP} VERBATIM)
 
-    add_library(amalgamated_hawktracer_cpp SHARED
+    add_library(amalgamated_hawktracer_cpp ${HAWKTRACER_LIB_TYPE}
         hawktracer.cpp)
 endif()


### PR DESCRIPTION
Issue #75: Get amalgamated files to generate libraries that are of same type as hawktracer library (all shared or all static)

Signed-off-by: Gilles Talis <gilles.talis@gmail.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
